### PR TITLE
Fixed limitation on randomness of word index.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,8 @@ while an incorrect guess yields an API response that looks like this:
 }
 ```
 ### Pseudorandomness
-The word of the day is pseudorandomly-selected by pseudorandomly-generating an index seeded by the current day number of the year (i.e. March 12, 2022 is Day 71). Because of this, there currently are only 365 "pseudorandomly-selected" words that will end up being used. See the limitations section below for the proposed solution. 
+The word of the day is pseudorandomly-selected by generating an index seeded by the number of days the current day is from 01/01/2000.
 
 ### Limitations
-- Because we use the current day number of the year as the seed to pseudorandomly generate an index to select our word of the day, there are only 365 pseudorandomly-selected words. 
-	- Soon, we will use a different seed, that still changes every day at midnight, that will get rid of this limitation.
-	- The intended solution is going to be to just count the number of days it is FROM an arbitrary date. 
 - Currently, the word bank only consits of 5-letter words. Eventually, shorter (4-letter) and longer (6-, 7-, 8- letter) words will be added
 - The API does not currently check to see if a guess is in the word bank, which is a feature of many Wordle clones, as well as Wordle itself.

--- a/word-util/util.ts
+++ b/word-util/util.ts
@@ -4,10 +4,14 @@ import { five_char_words } from "./word_list";
 let cached_date: Date = new Date();
 let cached_idx = -1;
 
-const getDayOfYear = (date: Date): number => {
+/**
+ * Determines the number of days a specific `Date` has been since 01/01/2000.
+ * @param date The `Date` in question
+ * @returns The number of days `date` has been since 01/01/2000.
+ */
+const getDayDiff = (date: Date): number => {
 	return Math.floor(
-		(date.valueOf() - new Date(date.getFullYear(), 0, 0).valueOf()) /
-			(1000 * 60 * 60 * 24)
+		(date.valueOf() - new Date(2000, 0, 0).valueOf()) / (1000 * 60 * 60 * 24)
 	);
 };
 
@@ -54,9 +58,9 @@ const getWordOfTheDay = (): string => {
 	}
 
 	cached_date = date; // Cache the date
-	const rng = seedrandom(getDayOfYear(date).toString());
+	const rng = seedrandom(getDayDiff(date).toString());
 	let idx: number = Math.floor(rng() * five_char_words.length);
 	cached_idx = idx; // Cache the index.
 	return five_char_words[idx];
 };
-export { getWordOfTheDay, getDayOfYear, isCharInWord };
+export { getWordOfTheDay, getDayDiff as getDayOfYear, isCharInWord };


### PR DESCRIPTION
We no longer have to worry about how random the word of the day is. Instead of using the day of the year to seed the random number generator, we use the number of days it has been since 01/01/2000. That way, every seed will (hopefully) be different and never repeat, leading to more randomness.